### PR TITLE
disable dependabot updates for the time being

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,25 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "pip"
-    directory: "/back-end"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "npm"
-    directory: "/front-end/enbalde"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-
-  - package-ecosystem: "npm"
-    directory: "/front-end/enbaldePago"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
+#version: 2
+#updates:
+#  - package-ecosystem: "github-actions"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#      day: "thursday"
+#
+#  - package-ecosystem: "pip"
+#    directory: "/back-end"
+#    schedule:
+#      interval: "weekly"
+#      day: "thursday"
+#
+#  - package-ecosystem: "npm"
+#    directory: "/front-end/enbalde"
+#    schedule:
+#      interval: "weekly"
+#      day: "thursday"
+#
+#  - package-ecosystem: "npm"
+#    directory: "/front-end/enbaldePago"
+#    schedule:
+#      interval: "weekly"
+#      day: "thursday"


### PR DESCRIPTION
Deshabilitar dependabot para que no se actualicen los paquetes de js o python y que se rompa en el medio del cuatrimestre