### PR TITLE
add text showing no catalogue when empty or not connecting to server

### DIFF
--- a/app/app/src/main/java/com/ar/enbaldeapp/ui/catalogue/CatalogueFragment.java
+++ b/app/app/src/main/java/com/ar/enbaldeapp/ui/catalogue/CatalogueFragment.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -81,6 +82,16 @@ public class CatalogueFragment extends Fragment {
                         Snackbar.make(getView(), "Error retrieving cart from server: " + e.getMessage(), Snackbar.LENGTH_SHORT).show();
                     });
         });
+
+        TextView emptyView = root.findViewById(R.id.empty_catalogue_view);
+        if (adapter.getItemCount() == 0) {
+            recyclerView.setVisibility(View.GONE);
+            emptyView.setVisibility(View.VISIBLE);
+        }
+        else {
+            recyclerView.setVisibility(View.VISIBLE);
+            emptyView.setVisibility(View.GONE);
+        }
 
         return root;
     }

--- a/app/app/src/main/res/layout/fragment_catalogue.xml
+++ b/app/app/src/main/res/layout/fragment_catalogue.xml
@@ -16,4 +16,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/empty_catalogue_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:textStyle="bold"
+        android:textSize="24sp"
+        android:gravity="center"
+        android:visibility="gone"
+        android:text="No data available" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Si no hay ningún elemento en la lista (porque el servidor está vacío o caído) en lugar de reventar o mostrar pantalla blanca va a mostrar un texto que dice que no hay nada.